### PR TITLE
mamba release 2023.03.28 (libmamba/libmambapy 1.4.1)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "mamba" %}
-{% set libmamba_version = "1.3.1" %}
-{% set libmambapy_version = "1.3.1" %}
-{% set mamba_version = "1.3.1" %}
-{% set release = "2023.02.09" %}
+{% set libmamba_version = "1.4.1" %}
+{% set libmambapy_version = "1.4.1" %}
+{% set mamba_version = "1.4.1" %}
+{% set release = "2023.03.28" %}
 {% set build_mamba = "false" %}
 
 package:
@@ -10,10 +10,10 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  sha256: 21e12253a8360b5e0199649ce4c66a2a9830f0cd83811d9527c57c72a2a4ec84
+  sha256: 53ee26c7cf3730919cb6b40956a1fb591859ec12a037adc09da1ed390c2fdfb6
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: libmamba
@@ -39,7 +39,7 @@ outputs:
         - libcurl
         - openssl 1.1.1
         - libarchive
-        - nlohmann_json
+        - nlohmann_json 3.11.2
         - cpp-expected
         - reproc-cpp 14.2.4
         - reproc 14.2.4
@@ -47,7 +47,7 @@ outputs:
         - yaml-cpp
         - fmt 9.1.0
         - winreg  # [win]
-        - zstd 1.5.2
+        - zstd 1.5.4
         - bzip2 1.0
         - cli11
       run:
@@ -92,7 +92,7 @@ outputs:
         - pip
         - setuptools
         - wheel
-        - pybind11
+        - pybind11 2.10.1
         - pybind11-abi
         - openssl 1.1.1
         - yaml-cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ outputs:
         - libcurl
         - openssl 1.1.1
         - libarchive
-        - nlohmann_json 3.11.2
+        - nlohmann_json
         - cpp-expected
         - reproc-cpp 14.2.4
         - reproc 14.2.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,18 +38,18 @@ outputs:
         - libsolv 0.7.22
         - libcurl
         - openssl 1.1.1
-        - libarchive
-        - nlohmann_json
-        - cpp-expected
+        - libarchive 3.6.2
+        - nlohmann_json 3.11.2
+        - cpp-expected 1.0.0
         - reproc-cpp 14.2.4
         - reproc 14.2.4
         - spdlog 1.11.0
-        - yaml-cpp
+        - yaml-cpp 0.7.0
         - fmt 9.1.0
-        - winreg  # [win]
+        - winreg 4.1.2 # [win]
         - zstd 1.5.4
         - bzip2 1.0
-        - cli11
+        - cli11 2.1.2
       run:
         - libsolv >=0.7.22,<0.8.0a0
         - reproc-cpp >=14.2.4,<15.0a0
@@ -93,13 +93,13 @@ outputs:
         - setuptools
         - wheel
         - pybind11 2.10.1
-        - pybind11-abi
+        - pybind11-abi 4
         - openssl 1.1.1
-        - yaml-cpp
-        - cpp-expected
+        - yaml-cpp 0.7.0
+        - cpp-expected 1.0.0
         - spdlog 1.11.0
         - fmt 9.1.0
-        - nlohmann_json
+        - nlohmann_json 3.11.2
         - {{ pin_subpackage('libmamba', exact=True) }}
       run:
         - python


### PR DESCRIPTION
**Jira ticket:** [PKG-1376](https://anaconda.atlassian.net/browse/PKG-1376)

**The upstream data:**

1. **mamba** project
- Changelog: https://github.com/mamba-org/mamba/blob/2023.03.28/CHANGELOG.md#2023.03.28
- License: https://github.com/mamba-org/mamba/blob/2023.03.28/LICENSE
- Requirements:
  - https://github.com/mamba-org/mamba/blob/2023.03.28/CMakeLists.txt
  -  https://github.com/mamba-org/mamba/blob/2023.03.28/pyproject.toml

2. **libmamba**
- Changelog: https://github.com/mamba-org/mamba/blob/2023.03.28/libmamba/CHANGELOG.md
- License: https://github.com/mamba-org/mamba/blob/2023.03.28/libmamba/LICENSE
- Requirements:
  - https://github.com/mamba-org/mamba/blob/2023.03.28/libmamba/CMakeLists.txt

3. **libmambapy**
- Changelog: https://github.com/mamba-org/mamba/blob/2023.03.28/libmambapy/CHANGELOG.md
- License:
- Requirements:
  - https://github.com/mamba-org/mamba/blob/2023.03.28/libmambapy/CMakeLists.txt
  - https://github.com/mamba-org/mamba/blob/2023.03.28/libmambapy/setup.cfg
  - https://github.com/mamba-org/mamba/blob/2023.03.28/libmambapy/setup.py

**Actions**:
1. Reset build number
2. Add pinnings in host


**Notes**:
- `libmamba 1.4.1` requires a newer version **3.11.2** of `nlohmann_json` https://github.com/AnacondaRecipes/nlohmann_json-feedstock/pull/2

[PKG-1376]: https://anaconda.atlassian.net/browse/PKG-1376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ