### PR TITLE
mamba release 2023.09.05 (libmamba/libmambapy 1.5.1)

### DIFF
--- a/recipe/build_mamba.bat
+++ b/recipe/build_mamba.bat
@@ -5,7 +5,7 @@ echo "Building %PKG_NAME%."
 
 if /I "%PKG_NAME%" == "mamba" (
 	cd mamba
-	%PYTHON% -m pip install . --no-deps -vv
+	%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
 	exit 0
 )
 
@@ -14,7 +14,8 @@ mkdir build
 cd build
 if errorlevel 1 exit /b 1
 
-set "CXXFLAGS=%CXXFLAGS% /D_LIBCPP_DISABLE_AVAILABILITY=1"
+rem most likely don't needed on Windows, just for OSX
+rem set "CXXFLAGS=%CXXFLAGS% /D_LIBCPP_DISABLE_AVAILABILITY=1"
 
 :: Generate the build files.
 echo "Generating the build files..."
@@ -55,7 +56,7 @@ if errorlevel 1 exit /b 1
 if /I "%PKG_NAME%" == "libmambapy" (
 	cd ../libmambapy
 	rmdir /Q /S build
-	%PYTHON% -m pip install . --no-deps -vv
+	%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
 	del *.pyc /a /s
 )
 

--- a/recipe/build_mamba.sh
+++ b/recipe/build_mamba.sh
@@ -2,12 +2,12 @@
 
 if [[ $PKG_NAME == "mamba" ]]; then
     cd mamba || exit 1
-    $PYTHON -m pip install . --no-deps -vv
-
+    $PYTHON -m pip install . --no-deps --no-build-isolation -vv
+    
     echo "Adding link to mamba into condabin";
     mkdir -p $PREFIX/condabin
     ln -s $PREFIX/bin/mamba $PREFIX/condabin/mamba
-
+    
     exit 0
 fi
 
@@ -22,22 +22,22 @@ echo "Generating the build files..."
 
 if [[ $PKG_NAME == "libmamba" ]]; then
     cmake .. ${CMAKE_ARGS}              \
-        -GNinja                         \
-        -DCMAKE_INSTALL_PREFIX=$PREFIX  \
-        -DCMAKE_PREFIX_PATH=$PREFIX     \
-        -DCMAKE_BUILD_TYPE=Release      \
-        -DBUILD_LIBMAMBA=ON             \
-        -DBUILD_SHARED=ON               \
-        -DBUILD_MAMBA_PACKAGE=ON
-elif [[ $PKG_NAME == "libmambapy" ]]; then
+    -GNinja                         \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX  \
+    -DCMAKE_PREFIX_PATH=$PREFIX     \
+    -DCMAKE_BUILD_TYPE=Release      \
+    -DBUILD_LIBMAMBA=ON             \
+    -DBUILD_SHARED=ON               \
+    -DBUILD_MAMBA_PACKAGE=ON
+    elif [[ $PKG_NAME == "libmambapy" ]]; then
     # TODO finds wrong python interpreter!!!!
     cmake .. ${CMAKE_ARGS}              \
-        -GNinja                         \
-        -DCMAKE_PREFIX_PATH=$PREFIX     \
-        -DCMAKE_INSTALL_PREFIX=$PREFIX  \
-        -DCMAKE_BUILD_TYPE=Release      \
-        -DPython_EXECUTABLE=$PYTHON     \
-        -DBUILD_LIBMAMBAPY=ON
+    -GNinja                         \
+    -DCMAKE_PREFIX_PATH=$PREFIX     \
+    -DCMAKE_INSTALL_PREFIX=$PREFIX  \
+    -DCMAKE_BUILD_TYPE=Release      \
+    -DPython_EXECUTABLE=$PYTHON     \
+    -DBUILD_LIBMAMBAPY=ON
 fi
 
 # Build.
@@ -51,7 +51,7 @@ ninja install || exit 1
 if [[ $PKG_NAME == "libmambapy" ]]; then
     cd ../libmambapy || exit 1
     rm -rf build
-    $PYTHON -m pip install . --no-deps -vv
+    $PYTHON -m pip install . --no-deps --no-build-isolation -vv
     find libmambapy/bindings* -type f -print0 | xargs -0 rm -f --
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,10 +10,10 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  sha256: 53ee26c7cf3730919cb6b40956a1fb591859ec12a037adc09da1ed390c2fdfb6
+  sha256: 17f5be3077558250fc8ba02af68802cebe24d4b8d5bf5a602148ca54b43ebb10
 
 build:
-  number: 1
+  number: 0
 
 outputs:
   - name: libmamba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "mamba" %}
-{% set libmamba_version = "1.4.1" %}
-{% set libmambapy_version = "1.4.1" %}
-{% set mamba_version = "1.4.1" %}
-{% set release = "2023.03.28" %}
+{% set libmamba_version = "1.5.1" %}
+{% set libmambapy_version = "1.5.1" %}
+{% set mamba_version = "1.5.1" %}
+{% set release = "2023.09.05" %}
 {% set build_mamba = "false" %}
 
 package:
@@ -135,7 +135,7 @@ outputs:
         - {{ pin_subpackage('libmambapy', exact=True) }}
       run:
         - python
-        - conda >=4.14.0,<23.4
+        - conda >=4.14.0,<24.0a0
         - {{ pin_subpackage('libmambapy', exact=True) }}
 
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ outputs:
         - ninja
         - python            # [win]
       host:
-        - libsolv
+        - libsolv 0.7.24
         - libcurl
         - openssl {{ openssl }}
         - libarchive
@@ -51,7 +51,7 @@ outputs:
         - bzip2
         - cli11
       run:
-        - libsolv
+        - libsolv >=0.7.24,<0.8.0a0
         - reproc-cpp
         - reproc
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,25 +35,25 @@ outputs:
         - ninja
         - python            # [win]
       host:
-        - libsolv 0.7.22
-        - libcurl 7.88.1
+        - libsolv
+        - libcurl
         - openssl {{ openssl }}
-        - libarchive 3.6.2
-        - nlohmann_json 3.11.2
-        - cpp-expected 1.0.0
-        - reproc-cpp 14.2.4
-        - reproc 14.2.4
-        - spdlog 1.11.0
-        - yaml-cpp 0.7.0
-        - fmt 9.1.0
-        - winreg 4.1.2 # [win]
-        - zstd 1.5.4
-        - bzip2 1.0
-        - cli11 2.1.2
+        - libarchive
+        - nlohmann_json
+        - cpp-expected
+        - reproc-cpp
+        - reproc
+        - spdlog
+        - yaml-cpp
+        - fmt
+        - winreg  # [win]
+        - zstd
+        - bzip2
+        - cli11
       run:
-        - libsolv >=0.7.22,<0.8.0a0
-        - reproc-cpp >=14.2.4,<15.0a0
-        - reproc >=14.2.4,<15.0a0
+        - libsolv
+        - reproc-cpp
+        - reproc
     test:
       commands:
         - test -d ${PREFIX}/include/mamba                                   # [unix]
@@ -92,14 +92,14 @@ outputs:
         - pip
         - setuptools
         - wheel
-        - pybind11 2.10.1
-        - pybind11-abi 4
-        - openssl {{ openssl }}
-        - yaml-cpp 0.7.0
-        - cpp-expected 1.0.0
-        - spdlog 1.11.0
-        - fmt 9.1.0
-        - nlohmann_json 3.11.2
+        - pybind11
+        - pybind11-abi
+        - openssl
+        - yaml-cpp
+        - cpp-expected
+        - spdlog
+        - fmt
+        - nlohmann_json
         - {{ pin_subpackage('libmamba', exact=True) }}
       run:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,8 @@ outputs:
         - yaml-cpp
         - fmt
         - winreg  # [win]
-        - zstd
-        - bzip2
+        - zstd {{ zstd }}
+        - bzip2 {{ bzip2 }}
         - cli11
       run:
         - libsolv >=0.7.24,<0.8.0a0


### PR DESCRIPTION
Refs [PKG-2778](https://anaconda.atlassian.net/browse/PKG-2778)

[PKG-2778]: https://anaconda.atlassian.net/browse/PKG-2778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

One thing I'm not sure about is the many specific versions we're pinning, that may not be the same as what the mamba project has been testing when they relied on conda-forge package versions.

See the host section for the libmamba output: https://github.com/conda-forge/mamba-feedstock/blob/93ee6b3ac337673d3ab83212f88c96c03f94505f/recipe/meta.yaml#L34-L45