### PR TITLE
Update to 1.5.3

### DIFF
--- a/recipe/build_mamba.bat
+++ b/recipe/build_mamba.bat
@@ -5,7 +5,7 @@ echo "Building %PKG_NAME%."
 
 if /I "%PKG_NAME%" == "mamba" (
 	cd mamba
-	%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+	%PYTHON% -m pip install . --no-deps --no-build-isolation -v
 	exit 0
 )
 
@@ -56,7 +56,7 @@ if errorlevel 1 exit /b 1
 if /I "%PKG_NAME%" == "libmambapy" (
 	cd ../libmambapy
 	rmdir /Q /S build
-	%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+	%PYTHON% -m pip install . --no-deps --no-build-isolation -v
 	del *.pyc /a /s
 )
 

--- a/recipe/build_mamba.sh
+++ b/recipe/build_mamba.sh
@@ -2,7 +2,7 @@
 
 if [[ $PKG_NAME == "mamba" ]]; then
     cd mamba || exit 1
-    $PYTHON -m pip install . --no-deps --no-build-isolation -vv
+    $PYTHON -m pip install . --no-deps --no-build-isolation -v
     
     echo "Adding link to mamba into condabin";
     mkdir -p $PREFIX/condabin
@@ -51,7 +51,7 @@ ninja install || exit 1
 if [[ $PKG_NAME == "libmambapy" ]]; then
     cd ../libmambapy || exit 1
     rm -rf build
-    $PYTHON -m pip install . --no-deps --no-build-isolation -vv
+    $PYTHON -m pip install . --no-deps --no-build-isolation -v
     find libmambapy/bindings* -type f -print0 | xargs -0 rm -f --
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "mamba" %}
-{% set libmamba_version = "1.5.1" %}
-{% set libmambapy_version = "1.5.1" %}
-{% set mamba_version = "1.5.1" %}
-{% set release = "2023.09.05" %}
+{% set libmamba_version = "1.5.3" %}
+{% set libmambapy_version = "1.5.3" %}
+{% set mamba_version = "1.5.3" %}
+{% set release = "2023.10.30" %}
 {% set build_mamba = "false" %}
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  sha256: 17f5be3077558250fc8ba02af68802cebe24d4b8d5bf5a602148ca54b43ebb10
+  sha256: 36d617de5971ad2b4460f5446bee7622f33cf3a8a079df8f97bc24e9a5873071
 
 build:
   number: 0
@@ -44,7 +44,7 @@ outputs:
         - reproc-cpp
         - reproc
         - spdlog
-        - yaml-cpp
+        - yaml-cpp >=0.8.0
         - fmt
         - winreg  # [win]
         - zstd {{ zstd }}
@@ -95,7 +95,7 @@ outputs:
         - pybind11
         - pybind11-abi
         - openssl
-        - yaml-cpp
+        - yaml-cpp >=0.8.0
         - cpp-expected
         - spdlog
         - fmt


### PR DESCRIPTION
Update to 1.5.3.

The requirement for yaml-cpp comes from https://github.com/mamba-org/mamba/compare/2023.09.05..2023.10.30#diff-2a1acd5199d3752f2c9b633d7d95fc3b48fe4578845c48c6afca3852a17d4583R16 and libmambapy won't compile without this.