### PR TITLE
mamba release 2023.12.21 (libmamba/libmambapy 1.5.6)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "mamba" %}
-{% set libmamba_version = "1.5.3" %}
-{% set libmambapy_version = "1.5.3" %}
-{% set mamba_version = "1.5.3" %}
-{% set release = "2023.10.30" %}
+{% set libmamba_version = "1.5.6" %}
+{% set libmambapy_version = "1.5.6" %}
+{% set mamba_version = "1.5.6" %}
+{% set release = "2023.12.21" %}
 {% set build_mamba = "false" %}
 
 package:
@@ -10,7 +10,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  sha256: 36d617de5971ad2b4460f5446bee7622f33cf3a8a079df8f97bc24e9a5873071
+  sha256: 868bb00385029ae45b35e136174164017868edec6f3710bc1644c670db4c0cdb
 
 build:
   number: 0
@@ -135,7 +135,7 @@ outputs:
         - {{ pin_subpackage('libmambapy', exact=True) }}
       run:
         - python
-        - conda >=4.14.0,<24.0a0
+        - conda >=23.11,<24.0a0
         - {{ pin_subpackage('libmambapy', exact=True) }}
 
     test:


### PR DESCRIPTION
**Jira ticket:** [PKG-3714](https://anaconda.atlassian.net/browse/PKG-3714)

**The upstream data:**

1. **mamba** project
- Changelog: https://github.com/mamba-org/mamba/blob/2023.12.21/CHANGELOG.md#2023.12.21
- Requirements:
  - https://github.com/mamba-org/mamba/blob/2023.12.21/CMakeLists.txt
  -  https://github.com/mamba-org/mamba/blob/2023.12.21/pyproject.toml

2. **libmamba**
- Changelog: https://github.com/mamba-org/mamba/blob/2023.12.21/libmamba/CHANGELOG.md
- Requirements:
  - https://github.com/mamba-org/mamba/blob/2023.12.21/libmamba/CMakeLists.txt

3. **libmambapy**
- Changelog: https://github.com/mamba-org/mamba/blob/2023.12.21/libmambapy/CHANGELOG.md
- Requirements:
  - https://github.com/mamba-org/mamba/blob/2023.12.21/libmambapy/CMakeLists.txt
  - https://github.com/mamba-org/mamba/blob/2023.12.21/libmambapy/setup.cfg
  - https://github.com/mamba-org/mamba/blob/2023.12.21/libmambapy/setup.py

**Changes**:
1. Use `conda >=23.11,<24.0a0` for the `mamba` output



[PKG-3714]: https://anaconda.atlassian.net/browse/PKG-3714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ