### PR TITLE
Update to libmamba, libmambapy to 1.5.8 released Mar 25, 2024

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  https://github.com/mamba-org/mamba/archive/refs/tags/2024.03.25.tar.gz
   sha256: 6ddaf4b0758eb7ca1250f427bc40c2c3ede43257a60bac54e4320a4de66759a6
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "mamba" %}
-{% set libmamba_version = "1.5.6" %}
-{% set libmambapy_version = "1.5.6" %}
-{% set mamba_version = "1.5.6" %}
-{% set release = "2023.12.21" %}
+{% set libmamba_version = "1.5.8" %}
+{% set libmambapy_version = "1.5.8" %}
+{% set mamba_version = "1.5.8" %}
+{% set release = "2024.03.25" %}
 {% set build_mamba = "false" %}
 
 package:
@@ -10,7 +10,8 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  sha256: 868bb00385029ae45b35e136174164017868edec6f3710bc1644c670db4c0cdb
+  https://github.com/mamba-org/mamba/archive/refs/tags/2024.03.25.tar.gz
+  sha256: 6ddaf4b0758eb7ca1250f427bc40c2c3ede43257a60bac54e4320a4de66759a6
 
 build:
   number: 0


### PR DESCRIPTION
[PKG-4347](https://anaconda.atlassian.net/browse/PKG-4347)

[PKG-4347]: https://anaconda.atlassian.net/browse/PKG-4347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ