### PR TITLE
update to 1.5.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-build_parameters:
-  - "--suppress-variables"
-
-aggregate_branch: 3.12

--- a/recipe/build_mamba.bat
+++ b/recipe/build_mamba.bat
@@ -58,6 +58,7 @@ if /I "%PKG_NAME%" == "libmambapy" (
 	rmdir /Q /S build
 	%PYTHON% -m pip install . --no-deps --no-build-isolation -v
 	del *.pyc /a /s
+	del *.pyd /a /s
 )
 
 :: Error free exit.

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-c_compiler:  # [win]
-  - vs2019   # [win]
-cxx_compiler:  # [win]
-  - vs2019   # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "mamba" %}
-{% set libmamba_version = "1.5.8" %}
-{% set libmambapy_version = "1.5.8" %}
-{% set mamba_version = "1.5.8" %}
-{% set release = "2024.03.25" %}
+{% set libmamba_version = "1.5.11" %}
+{% set libmambapy_version = "1.5.11" %}
+{% set mamba_version = "1.5.11" %}
+{% set release = "2024.11.22" %}
 {% set build_mamba = "false" %}
 
 package:
@@ -10,10 +10,10 @@ package:
 
 source:
   url: https://github.com/{{ name }}-org/{{ name }}/archive/refs/tags/{{ release }}.tar.gz
-  sha256: 6ddaf4b0758eb7ca1250f427bc40c2c3ede43257a60bac54e4320a4de66759a6
+  sha256: 0791f5eac09611983bdd7c63dbfa046f7fb464525fa6c7967c40805093199d91
 
 build:
-  number: 3
+  number: 0
 
 outputs:
   - name: libmamba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - cmake
-        - ninja
+        - ninja-base
         - python            # [win]
       host:
         - libsolv 0.7.24
@@ -88,7 +88,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - cmake
-        - ninja
+        - ninja-base
       host:
         - python
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,6 +102,8 @@ outputs:
         - spdlog
         - fmt
         - nlohmann_json
+        - zstd {{ zstd }}
+        - bzip2 {{ bzip2 }}
         - {{ pin_subpackage('libmamba', exact=True) }}
       run:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,6 +82,8 @@ outputs:
         - {{ pin_subpackage('libmambapy', max_pin='x.x') }}
       ignore_run_exports:
         - spdlog
+      missing_dso_whitelist:  # [s390x]
+        - $RPATH/ld64.so.1    # [s390x] Known s390x `ld64.so` issue.
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
libmambapy 1.5.11

**Destination channel:** main

### Links

- https://anaconda.atlassian.net/browse/PKG-6280
- https://github.com/mamba-org/mamba/compare/libmambapy-1.5.8...libmambapy-1.5.11

Note: few changes done as a result of enabling error-overlinking.

