### PR TITLE
mamba 2.3.2 (rebuild)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - patches/0001-revert-use-range-in-solution.patch # [linux]
 
 build:
-  number: 2
+  number: 3
 
 outputs:
   - name: libmamba
@@ -33,7 +33,7 @@ outputs:
         - ninja-base
         - pkg-config
       host:
-        - libsolv 0.7.30
+        - libsolv 0.7.37
         - libcurl {{ libcurl }}
         - openssl {{ openssl }}
         - libarchive {{ libarchive }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -134,13 +134,13 @@ about:
     `mamba` is a reimplementation of the conda package manager in C++.
 
     - parallel downloading of repository data and package files using multi-threading
-    - libsolv for much faster dependency solving, a state of the art library used in the RPM package manager of Red Hat, Fedora and OpenSUSE
+    - libsolv for much faster dependency solving, a state-of-the-art library used in the RPM package manager of Red Hat, Fedora, and OpenSUSE
     - core parts of `mamba` are implemented in C++ for maximum efficiency
 
-    At the same time, `mamba` utilizes the same command line parser, package installation and deinstallation code and transaction verification routines as `conda` to stay as compatible as possible.
+    At the same time, `mamba` utilizes the same command line parser, package installation and deinstallation code, and transaction verification routines as `conda` to stay as compatible as possible.
 
     Mamba is part of a bigger ecosystem to make scientific packaging more sustainable. You can read our [announcement blog post](https://medium.com/@QuantStack/open-software-packaging-for-science-61cecee7fc23).
-    The ecosystem also consists of `quetz`, an open source `conda` package server and `boa`, a fast `conda` package builder.
+    The ecosystem also consists of `quetz`, an open source `conda` package server, and `boa`, a fast `conda` package builder.
 
     ### Installation
 
@@ -152,7 +152,7 @@ about:
 
     ### `repoquery`
 
-    To efficiently query repositories and query package dependencies you can use `mamba repoquery` or `micromamba repoquery`.
+    To efficiently query repositories and query package dependencies, you can use `mamba repoquery` or `micromamba repoquery`.
     See the [repoquery documentation](https://mamba.readthedocs.io/en/latest/user_guide/mamba.html#repoquery) for details.
 
     ### Installing lock files


### PR DESCRIPTION
mamba 2.3.2

**Destination channel:** defaults

### Links

- [PKG-14929](https://anaconda.atlassian.net/browse/PKG-14929) 

### Explanation of changes:

- Rebuild due libsolve 0.7.37


[PKG-14929]: https://anaconda.atlassian.net/browse/PKG-14929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ